### PR TITLE
Feat: MerkleTree basic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Simple implementation of a Merkle Tree built using Rust
 # Running
 ### Clone repository
 ```
-$ git clone https://github.com/LeanSerra/rusty-merkle-tree && cd rusty-merkle-tree
+git clone https://github.com/LeanSerra/rusty-merkle-tree && cd rusty-merkle-tree
 ```
 ### Run
 ```
-$ make
+make
 ```
 ### Run release mode
 ```
-$ make run_release
+make run_release
 ```
 ### Run tests
 ```
-$ make test
+make test
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,17 @@ mod merkle_tree;
 use merkle_tree::MerkleTree;
 
 fn main() {
-    let tree = MerkleTree::from_leaves(&["1", "2", "3", "4"]);
-    tree.print_layers();
+    let tree = MerkleTree::from_leaves(&["1", "2", "3", "4", "5"]);
+    println!("tree with 4 and 5");
+    println!("{tree}");
+    let mut tree = MerkleTree::from_leaves(&["1", "2", "3"]);
+    println!("Tree without 4 and 5");
+    println!("Before adding 4");
+    println!("{tree}");
+    tree.add_element("4");
+    println!("After adding 4 and before 5");
+    println!("{tree}");
+    tree.add_element("5");
+    println!("After adding 5");
+    println!("{tree}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
-use sha3::{Digest, Sha3_256};
+mod merkle_tree;
+
+use merkle_tree::MerkleTree;
 
 fn main() {
-    let mut hasher = Sha3_256::new();
-    hasher.update(b"1");
-    let hash = hasher.finalize();
-    assert_eq!(
-        "67b176705b46206614219f47a05aee7ae6a3edbe850bbbe214c536b989aea4d2",
-        hex::encode(hash)
-    );
+    let tree = MerkleTree::from_leaves(&["1", "2", "3", "4"]);
+    tree.print_layers();
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -2,15 +2,12 @@ use sha3::{Digest, Sha3_256};
 
 pub type Hash = [u8; 32];
 
+#[derive(Default)]
 pub struct MerkleTree {
     layers: Vec<Vec<Hash>>,
 }
 
 impl MerkleTree {
-    fn default() -> Self {
-        Self { layers: Vec::new() }
-    }
-
     pub fn from_leaves<T: std::convert::AsRef<[u8]>>(leaves: &[T]) -> Self {
         let mut tree = Self::default();
         tree.build_first_layer(leaves);

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -124,4 +124,87 @@ impl MerkleTree {
             self.layers.insert(0, vec![hasher.finalize().into()]);
         }
     }
+
+    #[cfg(test)]
+    pub fn get_root(&self) -> Option<Hash> {
+        match self.layers.first() {
+            Some(root_layer) => root_layer.first().copied(),
+            None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn tree_creation_power_of_two() {
+        let tree = MerkleTree::from_leaves(&["1", "2", "3", "4"]);
+        assert_eq!(
+            Some([
+                137, 153, 44, 123, 164, 130, 79, 195, 21, 135, 186, 74, 94, 220, 125, 98, 73, 20,
+                100, 119, 87, 220, 77, 185, 218, 60, 243, 252, 72, 120, 28, 89
+            ]),
+            tree.get_root()
+        );
+    }
+
+    #[test]
+    fn tree_creation_not_power_of_two() {
+        let tree = MerkleTree::from_leaves(&["1", "2", "3"]);
+        assert_eq!(
+            Some([
+                98, 188, 83, 184, 206, 109, 0, 66, 150, 238, 25, 116, 106, 0, 246, 132, 255, 226,
+                108, 94, 28, 117, 105, 41, 66, 101, 52, 101, 72, 97, 26, 94
+            ]),
+            tree.get_root()
+        );
+    }
+
+    #[test]
+    fn empty_tree() {
+        let leaves: Vec<String> = Vec::new();
+        let tree = MerkleTree::from_leaves(&leaves);
+        assert_eq!(None, tree.get_root())
+    }
+
+    #[test]
+    fn tree_add_element() {
+        let leaves: Vec<String> = Vec::new();
+        let mut tree = MerkleTree::from_leaves(&leaves);
+        assert_eq!(None, tree.get_root());
+        tree.add_element("1");
+        assert_eq!(
+            Some([
+                103, 177, 118, 112, 91, 70, 32, 102, 20, 33, 159, 71, 160, 90, 238, 122, 230, 163,
+                237, 190, 133, 11, 187, 226, 20, 197, 54, 185, 137, 174, 164, 210
+            ]),
+            tree.get_root()
+        );
+        tree.add_element("2");
+        assert_eq!(
+            Some([
+                129, 126, 89, 113, 153, 50, 84, 184, 160, 87, 205, 216, 126, 177, 231, 150, 152,
+                165, 130, 249, 154, 118, 205, 125, 38, 65, 70, 141, 241, 48, 219, 0
+            ]),
+            tree.get_root()
+        );
+        tree.add_element("3");
+        assert_eq!(
+            Some([
+                98, 188, 83, 184, 206, 109, 0, 66, 150, 238, 25, 116, 106, 0, 246, 132, 255, 226,
+                108, 94, 28, 117, 105, 41, 66, 101, 52, 101, 72, 97, 26, 94
+            ]),
+            tree.get_root()
+        );
+        tree.add_element("4");
+        assert_eq!(
+            Some([
+                137, 153, 44, 123, 164, 130, 79, 195, 21, 135, 186, 74, 94, 220, 125, 98, 73, 20,
+                100, 119, 87, 220, 77, 185, 218, 60, 243, 252, 72, 120, 28, 89
+            ]),
+            tree.get_root()
+        );
+    }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -27,7 +27,7 @@ impl MerkleTree {
         let mut tree = Self::default();
         tree.layers.push(Self::build_first_layer(leaves));
         while let Some(previous_layer) = tree.layers.first() {
-            if previous_layer.len() == 1 {
+            if previous_layer.len() <= 1 {
                 break;
             }
             let next_layer = Self::build_next_layer(previous_layer);

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -1,0 +1,43 @@
+use sha3::{Digest, Sha3_256};
+
+pub type Hash = [u8; 32];
+
+pub struct MerkleTree {
+    layers: Vec<Vec<Hash>>,
+}
+
+impl MerkleTree {
+    fn default() -> Self {
+        Self { layers: Vec::new() }
+    }
+
+    pub fn from_leaves<T: std::convert::AsRef<[u8]>>(leaves: &[T]) -> Self {
+        let mut tree = Self::default();
+        tree.build_first_layer(leaves);
+        tree
+    }
+
+    fn build_first_layer<T: std::convert::AsRef<[u8]>>(&mut self, leaves: &[T]) {
+        let mut hasher = Sha3_256::new();
+        let mut first_layer: Vec<[u8; 32]> = Vec::new();
+        for leave in leaves {
+            hasher.update(leave);
+            first_layer.push(hasher.finalize_reset().into());
+        }
+        self.layers.push(first_layer);
+    }
+
+    pub fn print_layers(self) {
+        for (i, layer) in self.layers.iter().enumerate() {
+            println!("Layer {i}: {{");
+            for hash in layer {
+                println!("{}", hex::encode(hash));
+            }
+            println!("}}");
+        }
+    }
+
+    fn build_tree(&mut self) {
+        todo!("Implement logic to build tree");
+    }
+}

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -62,4 +62,66 @@ impl MerkleTree {
         }
         next_layer
     }
+
+    pub fn add_element<T: std::convert::AsRef<[u8]>>(&mut self, elem: T) {
+        let mut hasher = Sha3_256::new();
+        let Some(last_layer) = self.layers.last_mut() else {
+            return;
+        };
+        hasher.update(elem);
+        last_layer.push(hasher.finalize_reset().into());
+
+        // The element is the first on the tree
+        if last_layer.len() == 1 {
+            return;
+        }
+        // We need to create the root layer
+        if last_layer.len() == 2 {
+            hasher.update(last_layer[0]);
+            hasher.update(last_layer[1]);
+            self.layers.insert(0, vec![hasher.finalize().into()]);
+            return;
+        }
+        // We have 2 or more layers
+        let mut prev_idx = self.layers.len() - 1;
+        let mut curr_idx = self.layers.len() - 2;
+
+        loop {
+            let previous_layer = self.layers[prev_idx].clone();
+            let current_layer = &mut self.layers[curr_idx];
+            let previous_layer_elem_count = previous_layer.len();
+
+            if (previous_layer.len() - 1) % 2 == 0 {
+                // Duplicate left node
+                hasher.update(previous_layer[previous_layer_elem_count - 1]);
+                hasher.update(previous_layer[previous_layer_elem_count - 1]);
+                current_layer.push(hasher.finalize_reset().into());
+            } else {
+                hasher.update(previous_layer[previous_layer_elem_count - 2]);
+                hasher.update(previous_layer[previous_layer_elem_count - 1]);
+                let Some(last_element) = current_layer.last_mut() else {
+                    panic!();
+                };
+                *last_element = hasher.finalize_reset().into();
+            }
+
+            if curr_idx > 0 {
+                curr_idx -= 1;
+            } else {
+                break;
+            }
+            prev_idx -= 1;
+        }
+
+        let Some(first_layer) = self.layers.first() else {
+            panic!()
+        };
+
+        // We need to create the last layer
+        if first_layer.len() != 1 {
+            hasher.update(first_layer[0]);
+            hasher.update(first_layer[1]);
+            self.layers.insert(0, vec![hasher.finalize().into()]);
+        }
+    }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use sha3::{Digest, Sha3_256};
 
 pub type Hash = [u8; 32];
@@ -5,6 +7,19 @@ pub type Hash = [u8; 32];
 #[derive(Default)]
 pub struct MerkleTree {
     layers: Vec<Vec<Hash>>,
+}
+
+impl Display for MerkleTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (idx, layer) in self.layers.iter().enumerate() {
+            writeln!(f, "Layer: {idx}: {{")?;
+            for hash in layer {
+                writeln!(f, "\t{}", hex::encode(hash))?;
+            }
+            writeln!(f, "}}")?;
+        }
+        Ok(())
+    }
 }
 
 impl MerkleTree {


### PR DESCRIPTION
**This PR**
- Add MerkleTree struct with functions to create the first layer of the tree and to print the tree
- Add type Hash, an array of 32 bytes
- Add `from_leaves` to create a tree from an array of elements that can be transforemed into bytes
- Add `add_element` to add an element to the tree
- Add Display trait to print the tree layers
- Add tests 
  - creating trees with power of two amount of elements
  - creating trees with odd amount of elements
  - creating empty tree
  - creating empty tree and adding elements